### PR TITLE
chore: fix release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint": "aegir run lint",
     "dep-check": "aegir run dep-check",
     "release": "run-s build docs:no-publish npm:release docs",
+    "npm:release": "aegir run release",
     "docs": "NODE_OPTIONS=--max_old_space_size=8192 aegir docs -- --exclude packages/interop --excludeExternals",
     "docs:no-publish": "NODE_OPTIONS=--max_old_space_size=8192 aegir docs --publish false -- --exclude packages/interop"
   },


### PR DESCRIPTION
fixes CI failure on unfound `npm:release` script

see https://github.com/ipfs/helia-strings/actions/runs/6430819758/job/17462670283
